### PR TITLE
Change from _nostring to _other

### DIFF
--- a/lib/plugins/config/settings/config.class.php
+++ b/lib/plugins/config/settings/config.class.php
@@ -1186,7 +1186,7 @@ if (!class_exists('setting_multicheckbox')) {
 
         var $_choices = array();
         var $_combine = array();
-        var $_nostring = '';
+        var $_other = 'always';
 
         /**
          * update changed setting with user provided value $input
@@ -1270,16 +1270,20 @@ if (!class_exists('setting_multicheckbox')) {
             }
 
             // handle any remaining values
-            if ($this->_nostring != 'on') {
+            if ($this->_other != 'never'){
                 $other = join(',',$value);
-    
-                $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?
-                                " selectiondefault" : "";
-    
-                $input .= '<div class="other'.$class.'">'."\n";
-                $input .= '<label for="config___'.$key.'_other">'.$plugin->getLang($key.'_other')."</label>\n";
-                $input .= '<input id="config___'.$key.'_other" name="config['.$key.'][other]" type="text" class="edit" value="'.htmlspecialchars($other).'" '.$disable." />\n";
-                $input .= "</div>\n";
+                // test equivalent to ($this->_other == 'always' || ($other && $this->_other == 'exists')
+                // use != 'exists' rather than == 'always' to ensure invalid values default to 'always'
+                if ($this->_other != 'exists' || $other) {
+
+                    $class = ((count($default) == count($value)) && (count($value) == count(array_intersect($value,$default)))) ?
+                                    " selectiondefault" : "";
+
+                    $input .= '<div class="other'.$class.'">'."\n";
+                    $input .= '<label for="config___'.$key.'_other">'.$plugin->getLang($key.'_other')."</label>\n";
+                    $input .= '<input id="config___'.$key.'_other" name="config['.$key.'][other]" type="text" class="edit" value="'.htmlspecialchars($other).'" '.$disable." />\n";
+                    $input .= "</div>\n";
+                }
             }
             $label = '<label>'.$this->prompt($plugin).'</label>';
             return array($label,$input);

--- a/lib/plugins/config/settings/config.metadata.php
+++ b/lib/plugins/config/settings/config.metadata.php
@@ -70,6 +70,12 @@
  *   '_pregflags'  - string, default 'ui', valid preg pattern modifiers used when testing regex input values, for more
  *                   information see http://uk1.php.net/manual/en/reference.pcre.pattern.modifiers.php
  *   '_multiple'   - bool, allow multiple comma separated email values; optional for 'email', ignored by others
+ *   '_other'      - how to handle other values (not listed in _choices). accepted values: 'always','exists','never'
+ *                   default value 'always'. 'exists' only shows 'other' input field when the setting contains value(s)
+ *                   not listed in choices (e.g. due to manual editing or update changing _choices).  This is safer than
+ *                   'never' as it will not discard unknown/other values.
+ *                   optional for 'multicheckbox', ignored by others
+ *
  *
  * @author    Chris Smith <chris@jalakai.co.uk>
  */


### PR DESCRIPTION
Permit three values:
- always (default), the other input field is always displayed
- exists, the other input field is only displayed when the setting
        contains value(s) not listed in choices*.
- never, the other input field is never displayed. If the setting
       contains any value(s) not listed in choices they will be
       discarded on saving.

*This means, under normal circumstances the admin will not see the other input field.  It will only appear after manual editing to enter a non-listed _choice or if an update were to remove a previously selected _choice
